### PR TITLE
Rename files with duplicate names

### DIFF
--- a/rainfall/conftest.py
+++ b/rainfall/conftest.py
@@ -75,8 +75,8 @@ def releases_user(app, sites_user):
     sites_user.sites[0].releases.append(
         Release(name='Site 0 Release 2',
                 files=[
-                    File(filename='s0_r1_file_0'),
-                    File(filename='s0_r1_file_1')
+                    File(filename='s0_r1_file_0.wav'),
+                    File(filename='s0_r1_file_1.aiff')
                 ]))
     sites_user.sites[1].releases.append(Release(name='Site 1 Release 1'))
 

--- a/rainfall/models/file.py
+++ b/rainfall/models/file.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, fields
 from functools import partial
+import re
 
 from sqlalchemy import ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -7,6 +8,9 @@ from sqlalchemy.types import Uuid, String
 from uuid_extensions import uuid7
 
 from rainfall.db import db
+
+RE_NAME = re.compile(r'(.+)((_\d+)?\..+)')
+RE_DUPE_NAME = re.compile(r'(.+)((_\d+)(\..+))')
 
 
 @dataclass
@@ -17,6 +21,7 @@ class File(db.Model):
   release_id: Mapped[bytes] = mapped_column(ForeignKey("releases.id"))
   release: Mapped["Release"] = relationship(back_populates="files")
   filename: Mapped[str] = mapped_column(String(1024))
+  original_filename: Mapped[str] = mapped_column(String(1024), nullable=True)
 
   def __repr__(self) -> str:
     return f'File(id={self.id!r}, release_id={self.release_id!r})'
@@ -25,3 +30,44 @@ class File(db.Model):
     return dict((field.name, getattr(self, field.name))
                 for field in fields(self)
                 if field.name != 'release')
+
+  def _new_name(self):
+    if self.release is None:
+      raise ValueError('Cannot rename a file that does not belong to a release')
+
+    dupe_file = None
+    for f in self.release.files:
+      if self is f:
+        continue
+      if self.filename == f.filename:
+        dupe_file = f
+        break
+
+    if dupe_file is None:
+      # Return whether rename was necessary.
+      return False
+    dupe_name = dupe_file.filename
+
+    regex = RE_NAME if dupe_file.original_filename is None else RE_DUPE_NAME
+    md = regex.match(dupe_name)
+    if not md:
+      raise ValueError(f'Invalid file, name={dupe_file.filename}, '
+                       f'original_name={dupe_file.original_filename}')
+
+    if dupe_file.original_filename is not None:
+      # Increment the numerical part, minus the _
+      num = int(md.group(3).split('_')[1]) + 1
+      new_name = f'{md.group(1)}_{num}{md.group(4)}'
+    else:
+      # Add a _1 tag to the name
+      new_name = f'{md.group(1)}_1{md.group(2)}'
+
+    # Return whether rename was necessary.
+    self.original_filename = self.filename
+    self.filename = new_name
+    return True
+
+  def maybe_rename(self):
+    # Keep trying names until a free one is found
+    while self._new_name():
+      pass

--- a/rainfall/models/file_test.py
+++ b/rainfall/models/file_test.py
@@ -1,0 +1,45 @@
+from rainfall.db import db
+from rainfall.models.file import File
+
+
+class FileTest:
+
+  def test_maybe_rename(self, app, releases_user):
+    with app.app_context():
+      db.session.add(releases_user)
+
+      release = releases_user.sites[0].releases[1]
+      file = File(filename='s0_r1_file_0.wav')
+      release.files.append(file)
+
+      file.maybe_rename()
+
+      assert file.filename == 's0_r1_file_0_1.wav'
+      assert file.original_filename == 's0_r1_file_0.wav'
+
+  def test_maybe_rename_10_times(self, app, releases_user):
+    with app.app_context():
+      db.session.add(releases_user)
+
+      release = releases_user.sites[0].releases[1]
+      for _ in range(10):
+        file = File(filename='s0_r1_file_0.wav')
+        release.files.append(file)
+
+        file.maybe_rename()
+
+      assert file.filename == 's0_r1_file_0_10.wav'
+      assert file.original_filename == 's0_r1_file_0_9.wav'
+
+  def test_maybe_rename_not_necessary(self, app, releases_user):
+    with app.app_context():
+      db.session.add(releases_user)
+
+      release = releases_user.sites[0].releases[1]
+      file = File(filename='foo.mp3')
+      release.files.append(file)
+
+      file.maybe_rename()
+
+      assert file.filename == 'foo.mp3'
+      assert file.original_filename is None

--- a/rainfall/models/file_test.py
+++ b/rainfall/models/file_test.py
@@ -1,3 +1,5 @@
+import pytest
+
 from rainfall.db import db
 from rainfall.models.file import File
 
@@ -43,3 +45,41 @@ class FileTest:
 
       assert file.filename == 'foo.mp3'
       assert file.original_filename is None
+
+  def test_rename_non_original_file(self, app, releases_user):
+    with app.app_context():
+      db.session.add(releases_user)
+
+      release = releases_user.sites[0].releases[1]
+      for _ in range(4):
+        file = File(filename='s0_r1_file_1.aiff')
+        release.files.append(file)
+
+        file.maybe_rename()
+
+      file = File(filename='s0_r1_file_1_2.aiff')
+      release.files.append(file)
+      file.maybe_rename()
+
+      assert file.filename == 's0_r1_file_1_5.aiff'
+      assert file.original_filename == 's0_r1_file_1_4.aiff'
+
+  def test_maybe_rename_no_release(self, app, releases_user):
+    with app.app_context():
+      db.session.add(releases_user)
+
+      file = File(filename='some_name.mp3')
+      with pytest.raises(ValueError):
+        file.maybe_rename()
+
+  def test_maybe_rename_other_file_degen_name(self, app, releases_user):
+    with app.app_context():
+      db.session.add(releases_user)
+
+      release = releases_user.sites[0].releases[1]
+      release.files.append(File(filename='foo_bad_name'))
+      file = File(filename='foo_bad_name')
+      release.files.append(file)
+
+      with pytest.raises(ValueError):
+        file.maybe_rename()


### PR DESCRIPTION
Fixes #6.

The rename scheme is:

- foo.mp3
- foo_1.mp3
- foo_2.mp3
- ...etc

In order to properly handle filenames that actually have `_\d+` as the last  characters before the file extension, we add the `original_filename` field to the `File` object. The value doesn't really matter, if we find a file with an `original_filename`, we know it's already been renamed and we can infer how to do the renaming.