### PR TITLE
Add CSRF protection

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ uuid7 = "*"
 pyjwt = {extras = ["crypto"], version = "*"}
 requests = "*"
 gunicorn = "*"
+flask-seasurf = {ref = "f383b482c69e0b0e8064a8eb89305cea3826a7b6", git = "git+https://github.com/maxcountryman/flask-seasurf"}
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "389dc043c8a96e5290d05e1b98e296f9198f5781af25c0a86a4cbcdcb0938f53"
+            "sha256": "ef785d3304d4abc35a791977a20bc04aa377ffb6b9f75cffefd6d15e0319d1ba"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -101,7 +101,8 @@
         "charset-normalizer": {
             "hashes": [
                 "sha256:3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc",
-                "sha256:90d558489962fd4918143277a773316e56c72da56ec7aa3dc3dbbe20fdfed15b",
+                "sha256:573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96",
+                "sha256:802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db",
                 "sha256:f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"
             ],
             "markers": "python_full_version >= '3.7.0'",
@@ -152,6 +153,10 @@
             "markers": "python_version >= '3.8'",
             "version": "==3.0.0"
         },
+        "flask-seasurf": {
+            "git": "git+https://github.com/maxcountryman/flask-seasurf",
+            "ref": null
+        },
         "flask-sqlalchemy": {
             "hashes": [
                 "sha256:4ba4be7f419dc72f4efd8802d69974803c37259dd42f3913b0dcf75c9447e0a0",
@@ -163,75 +168,76 @@
         },
         "google-auth": {
             "hashes": [
-                "sha256:d5d66b8f4f6e3273740d7bb73ddefa6c2d1ff691704bd407d51c6b5800e7c97b",
-                "sha256:dfd7b44935d498e106c08883b2dac0ad36d8aa10402a6412e9a1c9d74b4773f1"
+                "sha256:42f707937feb4f5e5a39e6c4f343a17300a459aaf03141457ba505812841cc40",
+                "sha256:473a8dfd0135f75bb79d878436e568f2695dce456764bf3a02b6f8c540b1d256"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==2.25.1"
+            "version": "==2.25.2"
         },
         "greenlet": {
             "hashes": [
-                "sha256:0a02d259510b3630f330c86557331a3b0e0c79dac3d166e449a39363beaae174",
-                "sha256:0b6f9f8ca7093fd4433472fd99b5650f8a26dcd8ba410e14094c1e44cd3ceddd",
-                "sha256:100f78a29707ca1525ea47388cec8a049405147719f47ebf3895e7509c6446aa",
-                "sha256:1757936efea16e3f03db20efd0cd50a1c86b06734f9f7338a90c4ba85ec2ad5a",
-                "sha256:19075157a10055759066854a973b3d1325d964d498a805bb68a1f9af4aaef8ec",
-                "sha256:19bbdf1cce0346ef7341705d71e2ecf6f41a35c311137f29b8a2dc2341374565",
-                "sha256:20107edf7c2c3644c67c12205dc60b1bb11d26b2610b276f97d666110d1b511d",
-                "sha256:22f79120a24aeeae2b4471c711dcf4f8c736a2bb2fabad2a67ac9a55ea72523c",
-                "sha256:2847e5d7beedb8d614186962c3d774d40d3374d580d2cbdab7f184580a39d234",
-                "sha256:28e89e232c7593d33cac35425b58950789962011cc274aa43ef8865f2e11f46d",
-                "sha256:329c5a2e5a0ee942f2992c5e3ff40be03e75f745f48847f118a3cfece7a28546",
-                "sha256:337322096d92808f76ad26061a8f5fccb22b0809bea39212cd6c406f6a7060d2",
-                "sha256:3fcc780ae8edbb1d050d920ab44790201f027d59fdbd21362340a85c79066a74",
-                "sha256:41bdeeb552d814bcd7fb52172b304898a35818107cc8778b5101423c9017b3de",
-                "sha256:4eddd98afc726f8aee1948858aed9e6feeb1758889dfd869072d4465973f6bfd",
-                "sha256:52e93b28db27ae7d208748f45d2db8a7b6a380e0d703f099c949d0f0d80b70e9",
-                "sha256:55d62807f1c5a1682075c62436702aaba941daa316e9161e4b6ccebbbf38bda3",
-                "sha256:5805e71e5b570d490938d55552f5a9e10f477c19400c38bf1d5190d760691846",
-                "sha256:599daf06ea59bfedbec564b1692b0166a0045f32b6f0933b0dd4df59a854caf2",
-                "sha256:60d5772e8195f4e9ebf74046a9121bbb90090f6550f81d8956a05387ba139353",
-                "sha256:696d8e7d82398e810f2b3622b24e87906763b6ebfd90e361e88eb85b0e554dc8",
-                "sha256:6e6061bf1e9565c29002e3c601cf68569c450be7fc3f7336671af7ddb4657166",
-                "sha256:80ac992f25d10aaebe1ee15df45ca0d7571d0f70b645c08ec68733fb7a020206",
-                "sha256:816bd9488a94cba78d93e1abb58000e8266fa9cc2aa9ccdd6eb0696acb24005b",
-                "sha256:85d2b77e7c9382f004b41d9c72c85537fac834fb141b0296942d52bf03fe4a3d",
-                "sha256:87c8ceb0cf8a5a51b8008b643844b7f4a8264a2c13fcbcd8a8316161725383fe",
-                "sha256:89ee2e967bd7ff85d84a2de09df10e021c9b38c7d91dead95b406ed6350c6997",
-                "sha256:8bef097455dea90ffe855286926ae02d8faa335ed8e4067326257cb571fc1445",
-                "sha256:8d11ebbd679e927593978aa44c10fc2092bc454b7d13fdc958d3e9d508aba7d0",
-                "sha256:91e6c7db42638dc45cf2e13c73be16bf83179f7859b07cfc139518941320be96",
-                "sha256:97e7ac860d64e2dcba5c5944cfc8fa9ea185cd84061c623536154d5a89237884",
-                "sha256:990066bff27c4fcf3b69382b86f4c99b3652bab2a7e685d968cd4d0cfc6f67c6",
-                "sha256:9fbc5b8f3dfe24784cee8ce0be3da2d8a79e46a276593db6868382d9c50d97b1",
-                "sha256:ac4a39d1abae48184d420aa8e5e63efd1b75c8444dd95daa3e03f6c6310e9619",
-                "sha256:b2c02d2ad98116e914d4f3155ffc905fd0c025d901ead3f6ed07385e19122c94",
-                "sha256:b2d3337dcfaa99698aa2377c81c9ca72fcd89c07e7eb62ece3f23a3fe89b2ce4",
-                "sha256:b489c36d1327868d207002391f662a1d163bdc8daf10ab2e5f6e41b9b96de3b1",
-                "sha256:b641161c302efbb860ae6b081f406839a8b7d5573f20a455539823802c655f63",
-                "sha256:b8ba29306c5de7717b5761b9ea74f9c72b9e2b834e24aa984da99cbfc70157fd",
-                "sha256:b9934adbd0f6e476f0ecff3c94626529f344f57b38c9a541f87098710b18af0a",
-                "sha256:ce85c43ae54845272f6f9cd8320d034d7a946e9773c693b27d620edec825e376",
-                "sha256:cf868e08690cb89360eebc73ba4be7fb461cfbc6168dd88e2fbbe6f31812cd57",
-                "sha256:d2905ce1df400360463c772b55d8e2518d0e488a87cdea13dd2c71dcb2a1fa16",
-                "sha256:d57e20ba591727da0c230ab2c3f200ac9d6d333860d85348816e1dca4cc4792e",
-                "sha256:d6a8c9d4f8692917a3dc7eb25a6fb337bff86909febe2f793ec1928cd97bedfc",
-                "sha256:d923ff276f1c1f9680d32832f8d6c040fe9306cbfb5d161b0911e9634be9ef0a",
-                "sha256:daa7197b43c707462f06d2c693ffdbb5991cbb8b80b5b984007de431493a319c",
-                "sha256:dbd4c177afb8a8d9ba348d925b0b67246147af806f0b104af4d24f144d461cd5",
-                "sha256:dc4d815b794fd8868c4d67602692c21bf5293a75e4b607bb92a11e821e2b859a",
-                "sha256:e9d21aaa84557d64209af04ff48e0ad5e28c5cca67ce43444e939579d085da72",
-                "sha256:ea6b8aa9e08eea388c5f7a276fabb1d4b6b9d6e4ceb12cc477c3d352001768a9",
-                "sha256:eabe7090db68c981fca689299c2d116400b553f4b713266b130cfc9e2aa9c5a9",
-                "sha256:f2f6d303f3dee132b322a14cd8765287b8f86cdc10d2cb6a6fae234ea488888e",
-                "sha256:f33f3258aae89da191c6ebaa3bc517c6c4cbc9b9f689e5d8452f7aedbb913fa8",
-                "sha256:f7bfb769f7efa0eefcd039dd19d843a4fbfbac52f1878b1da2ed5793ec9b1a65",
-                "sha256:f89e21afe925fcfa655965ca8ea10f24773a1791400989ff32f467badfe4a064",
-                "sha256:fa24255ae3c0ab67e613556375a4341af04a084bd58764731972bcbc8baeba36"
+                "sha256:01bc7ea167cf943b4c802068e178bbf70ae2e8c080467070d01bfa02f337ee67",
+                "sha256:0448abc479fab28b00cb472d278828b3ccca164531daab4e970a0458786055d6",
+                "sha256:086152f8fbc5955df88382e8a75984e2bb1c892ad2e3c80a2508954e52295257",
+                "sha256:098d86f528c855ead3479afe84b49242e174ed262456c342d70fc7f972bc13c4",
+                "sha256:149e94a2dd82d19838fe4b2259f1b6b9957d5ba1b25640d2380bea9c5df37676",
+                "sha256:1551a8195c0d4a68fac7a4325efac0d541b48def35feb49d803674ac32582f61",
+                "sha256:15d79dd26056573940fcb8c7413d84118086f2ec1a8acdfa854631084393efcc",
+                "sha256:1996cb9306c8595335bb157d133daf5cf9f693ef413e7673cb07e3e5871379ca",
+                "sha256:1a7191e42732df52cb5f39d3527217e7ab73cae2cb3694d241e18f53d84ea9a7",
+                "sha256:1ea188d4f49089fc6fb283845ab18a2518d279c7cd9da1065d7a84e991748728",
+                "sha256:1f672519db1796ca0d8753f9e78ec02355e862d0998193038c7073045899f305",
+                "sha256:2516a9957eed41dd8f1ec0c604f1cdc86758b587d964668b5b196a9db5bfcde6",
+                "sha256:2797aa5aedac23af156bbb5a6aa2cd3427ada2972c828244eb7d1b9255846379",
+                "sha256:2dd6e660effd852586b6a8478a1d244b8dc90ab5b1321751d2ea15deb49ed414",
+                "sha256:3ddc0f794e6ad661e321caa8d2f0a55ce01213c74722587256fb6566049a8b04",
+                "sha256:3ed7fb269f15dc662787f4119ec300ad0702fa1b19d2135a37c2c4de6fadfd4a",
+                "sha256:419b386f84949bf0e7c73e6032e3457b82a787c1ab4a0e43732898a761cc9dbf",
+                "sha256:43374442353259554ce33599da8b692d5aa96f8976d567d4badf263371fbe491",
+                "sha256:52f59dd9c96ad2fc0d5724107444f76eb20aaccb675bf825df6435acb7703559",
+                "sha256:57e8974f23e47dac22b83436bdcf23080ade568ce77df33159e019d161ce1d1e",
+                "sha256:5b51e85cb5ceda94e79d019ed36b35386e8c37d22f07d6a751cb659b180d5274",
+                "sha256:649dde7de1a5eceb258f9cb00bdf50e978c9db1b996964cd80703614c86495eb",
+                "sha256:64d7675ad83578e3fc149b617a444fab8efdafc9385471f868eb5ff83e446b8b",
+                "sha256:68834da854554926fbedd38c76e60c4a2e3198c6fbed520b106a8986445caaf9",
+                "sha256:6b66c9c1e7ccabad3a7d037b2bcb740122a7b17a53734b7d72a344ce39882a1b",
+                "sha256:70fb482fdf2c707765ab5f0b6655e9cfcf3780d8d87355a063547b41177599be",
+                "sha256:7170375bcc99f1a2fbd9c306f5be8764eaf3ac6b5cb968862cad4c7057756506",
+                "sha256:73a411ef564e0e097dbe7e866bb2dda0f027e072b04da387282b02c308807405",
+                "sha256:77457465d89b8263bca14759d7c1684df840b6811b2499838cc5b040a8b5b113",
+                "sha256:7f362975f2d179f9e26928c5b517524e89dd48530a0202570d55ad6ca5d8a56f",
+                "sha256:81bb9c6d52e8321f09c3d165b2a78c680506d9af285bfccbad9fb7ad5a5da3e5",
+                "sha256:881b7db1ebff4ba09aaaeae6aa491daeb226c8150fc20e836ad00041bcb11230",
+                "sha256:894393ce10ceac937e56ec00bb71c4c2f8209ad516e96033e4b3b1de270e200d",
+                "sha256:99bf650dc5d69546e076f413a87481ee1d2d09aaaaaca058c9251b6d8c14783f",
+                "sha256:9da2bd29ed9e4f15955dd1595ad7bc9320308a3b766ef7f837e23ad4b4aac31a",
+                "sha256:afaff6cf5200befd5cec055b07d1c0a5a06c040fe5ad148abcd11ba6ab9b114e",
+                "sha256:b1b5667cced97081bf57b8fa1d6bfca67814b0afd38208d52538316e9422fc61",
+                "sha256:b37eef18ea55f2ffd8f00ff8fe7c8d3818abd3e25fb73fae2ca3b672e333a7a6",
+                "sha256:b542be2440edc2d48547b5923c408cbe0fc94afb9f18741faa6ae970dbcb9b6d",
+                "sha256:b7dcbe92cc99f08c8dd11f930de4d99ef756c3591a5377d1d9cd7dd5e896da71",
+                "sha256:b7f009caad047246ed379e1c4dbcb8b020f0a390667ea74d2387be2998f58a22",
+                "sha256:bba5387a6975598857d86de9eac14210a49d554a77eb8261cc68b7d082f78ce2",
+                "sha256:c5e1536de2aad7bf62e27baf79225d0d64360d4168cf2e6becb91baf1ed074f3",
+                "sha256:c5ee858cfe08f34712f548c3c363e807e7186f03ad7a5039ebadb29e8c6be067",
+                "sha256:c9db1c18f0eaad2f804728c67d6c610778456e3e1cc4ab4bbd5eeb8e6053c6fc",
+                "sha256:d353cadd6083fdb056bb46ed07e4340b0869c305c8ca54ef9da3421acbdf6881",
+                "sha256:d46677c85c5ba00a9cb6f7a00b2bfa6f812192d2c9f7d9c4f6a55b60216712f3",
+                "sha256:d4d1ac74f5c0c0524e4a24335350edad7e5f03b9532da7ea4d3c54d527784f2e",
+                "sha256:d73a9fe764d77f87f8ec26a0c85144d6a951a6c438dfe50487df5595c6373eac",
+                "sha256:da70d4d51c8b306bb7a031d5cff6cc25ad253affe89b70352af5f1cb68e74b53",
+                "sha256:daf3cb43b7cf2ba96d614252ce1684c1bccee6b2183a01328c98d36fcd7d5cb0",
+                "sha256:dca1e2f3ca00b84a396bc1bce13dd21f680f035314d2379c4160c98153b2059b",
+                "sha256:dd4f49ae60e10adbc94b45c0b5e6a179acc1736cf7a90160b404076ee283cf83",
+                "sha256:e1f145462f1fa6e4a4ae3c0f782e580ce44d57c8f2c7aae1b6fa88c0b2efdb41",
+                "sha256:e3391d1e16e2a5a1507d83e4a8b100f4ee626e8eca43cf2cadb543de69827c4c",
+                "sha256:fcd2469d6a2cf298f198f0487e0a5b1a47a42ca0fa4dfd1b6862c999f018ebbf",
+                "sha256:fd096eb7ffef17c456cfa587523c5f92321ae02427ff955bebe9e3c63bc9f0da",
+                "sha256:fe754d231288e1e64323cfad462fcee8f0288654c10bdf4f603a39ed923bef33"
             ],
             "markers": "platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))",
-            "version": "==3.0.1"
+            "version": "==3.0.3"
         },
         "gunicorn": {
             "hashes": [
@@ -458,11 +464,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0",
-                "sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef"
+                "sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783",
+                "sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==4.8.0"
+            "version": "==4.9.0"
         },
         "urllib3": {
             "hashes": [
@@ -496,11 +502,61 @@
                 "toml"
             ],
             "hashes": [
-                "sha256:be32ad29341b0170e795ca590e1c07e81fc061cb5b10c74ce7203491484404ef",
-                "sha256:f6e9589bd04d0461a417562649522575d8752904d35c12907d8c9dfeba588faf"
+                "sha256:04387a4a6ecb330c1878907ce0dc04078ea72a869263e53c72a1ba5bbdf380ca",
+                "sha256:0676cd0ba581e514b7f726495ea75aba3eb20899d824636c6f59b0ed2f88c471",
+                "sha256:0e8d06778e8fbffccfe96331a3946237f87b1e1d359d7fbe8b06b96c95a5407a",
+                "sha256:0eb3c2f32dabe3a4aaf6441dde94f35687224dfd7eb2a7f47f3fd9428e421058",
+                "sha256:109f5985182b6b81fe33323ab4707011875198c41964f014579cf82cebf2bb85",
+                "sha256:13eaf476ec3e883fe3e5fe3707caeb88268a06284484a3daf8250259ef1ba143",
+                "sha256:164fdcc3246c69a6526a59b744b62e303039a81e42cfbbdc171c91a8cc2f9446",
+                "sha256:26776ff6c711d9d835557ee453082025d871e30b3fd6c27fcef14733f67f0590",
+                "sha256:26f66da8695719ccf90e794ed567a1549bb2644a706b41e9f6eae6816b398c4a",
+                "sha256:29f3abe810930311c0b5d1a7140f6395369c3db1be68345638c33eec07535105",
+                "sha256:316543f71025a6565677d84bc4df2114e9b6a615aa39fb165d697dba06a54af9",
+                "sha256:36b0ea8ab20d6a7564e89cb6135920bc9188fb5f1f7152e94e8300b7b189441a",
+                "sha256:3cc9d4bc55de8003663ec94c2f215d12d42ceea128da8f0f4036235a119c88ac",
+                "sha256:485e9f897cf4856a65a57c7f6ea3dc0d4e6c076c87311d4bc003f82cfe199d25",
+                "sha256:5040148f4ec43644702e7b16ca864c5314ccb8ee0751ef617d49aa0e2d6bf4f2",
+                "sha256:51456e6fa099a8d9d91497202d9563a320513fcf59f33991b0661a4a6f2ad450",
+                "sha256:53d7d9158ee03956e0eadac38dfa1ec8068431ef8058fe6447043db1fb40d932",
+                "sha256:5a10a4920def78bbfff4eff8a05c51be03e42f1c3735be42d851f199144897ba",
+                "sha256:5b14b4f8760006bfdb6e08667af7bc2d8d9bfdb648351915315ea17645347137",
+                "sha256:5b2ccb7548a0b65974860a78c9ffe1173cfb5877460e5a229238d985565574ae",
+                "sha256:697d1317e5290a313ef0d369650cfee1a114abb6021fa239ca12b4849ebbd614",
+                "sha256:6ae8c9d301207e6856865867d762a4b6fd379c714fcc0607a84b92ee63feff70",
+                "sha256:707c0f58cb1712b8809ece32b68996ee1e609f71bd14615bd8f87a1293cb610e",
+                "sha256:74775198b702868ec2d058cb92720a3c5a9177296f75bd97317c787daf711505",
+                "sha256:756ded44f47f330666843b5781be126ab57bb57c22adbb07d83f6b519783b870",
+                "sha256:76f03940f9973bfaee8cfba70ac991825611b9aac047e5c80d499a44079ec0bc",
+                "sha256:79287fd95585ed36e83182794a57a46aeae0b64ca53929d1176db56aacc83451",
+                "sha256:799c8f873794a08cdf216aa5d0531c6a3747793b70c53f70e98259720a6fe2d7",
+                "sha256:7d360587e64d006402b7116623cebf9d48893329ef035278969fa3bbf75b697e",
+                "sha256:80b5ee39b7f0131ebec7968baa9b2309eddb35b8403d1869e08f024efd883566",
+                "sha256:815ac2d0f3398a14286dc2cea223a6f338109f9ecf39a71160cd1628786bc6f5",
+                "sha256:83c2dda2666fe32332f8e87481eed056c8b4d163fe18ecc690b02802d36a4d26",
+                "sha256:846f52f46e212affb5bcf131c952fb4075b55aae6b61adc9856222df89cbe3e2",
+                "sha256:936d38794044b26c99d3dd004d8af0035ac535b92090f7f2bb5aa9c8e2f5cd42",
+                "sha256:9864463c1c2f9cb3b5db2cf1ff475eed2f0b4285c2aaf4d357b69959941aa555",
+                "sha256:995ea5c48c4ebfd898eacb098164b3cc826ba273b3049e4a889658548e321b43",
+                "sha256:a1526d265743fb49363974b7aa8d5899ff64ee07df47dd8d3e37dcc0818f09ed",
+                "sha256:a56de34db7b7ff77056a37aedded01b2b98b508227d2d0979d373a9b5d353daa",
+                "sha256:a7c97726520f784239f6c62506bc70e48d01ae71e9da128259d61ca5e9788516",
+                "sha256:b8e99f06160602bc64da35158bb76c73522a4010f0649be44a4e167ff8555952",
+                "sha256:bb1de682da0b824411e00a0d4da5a784ec6496b6850fdf8c865c1d68c0e318dd",
+                "sha256:bf477c355274a72435ceb140dc42de0dc1e1e0bf6e97195be30487d8eaaf1a09",
+                "sha256:bf635a52fc1ea401baf88843ae8708591aa4adff875e5c23220de43b1ccf575c",
+                "sha256:bfd5db349d15c08311702611f3dccbef4b4e2ec148fcc636cf8739519b4a5c0f",
+                "sha256:c530833afc4707fe48524a44844493f36d8727f04dcce91fb978c414a8556cc6",
+                "sha256:cc6d65b21c219ec2072c1293c505cf36e4e913a3f936d80028993dd73c7906b1",
+                "sha256:cd3c1e4cb2ff0083758f09be0f77402e1bdf704adb7f89108007300a6da587d0",
+                "sha256:cfd2a8b6b0d8e66e944d47cdec2f47c48fef2ba2f2dff5a9a75757f64172857e",
+                "sha256:d0ca5c71a5a1765a0f8f88022c52b6b8be740e512980362f7fdbb03725a0d6b9",
+                "sha256:e7defbb9737274023e2d7af02cac77043c86ce88a907c58f42b580a97d5bcca9",
+                "sha256:e9d1bf53c4c8de58d22e0e956a79a5b37f754ed1ffdbf1a260d9dcfa2d8a325e",
+                "sha256:ea81d8f9691bb53f4fb4db603203029643caffc82bf998ab5b59ca05560f4c06"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==7.3.2"
+            "version": "==7.4.0"
         },
         "iniconfig": {
             "hashes": [

--- a/rainfall-frontend/cypress/e2e/home.cy.ts
+++ b/rainfall-frontend/cypress/e2e/home.cy.ts
@@ -43,7 +43,7 @@ describe('Home Test', () => {
     });
 
     it('logs them out when they click sign out', () => {
-      cy.intercept('GET', 'api/v1/logout', cy.spy().as('logout'));
+      cy.intercept('POST', 'api/v1/logout', cy.spy().as('logout'));
       cy.get('button.sign-out').click();
       cy.get('@logout').should('have.been.calledOnce');
     });

--- a/rainfall-frontend/src/components/AddReleaseButton.vue
+++ b/rainfall-frontend/src/components/AddReleaseButton.vue
@@ -13,15 +13,11 @@ export default {
   methods: {
     async createRelease() {
       this.createError = false;
-      const csrfToken = await getCsrf();
-      if (!csrfToken) {
-        return;
-      }
       const resp = await fetch('/api/v1/release', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'X-CSRFToken': csrfToken,
+          'X-CSRFToken': await getCsrf(),
         },
         body: JSON.stringify({
           release: {

--- a/rainfall-frontend/src/components/AddReleaseButton.vue
+++ b/rainfall-frontend/src/components/AddReleaseButton.vue
@@ -1,4 +1,6 @@
 <script lang="ts">
+import { getCsrf } from '../helpers/cookie';
+
 export default {
   props: ['cardinality', 'siteId'],
   data(): {
@@ -11,10 +13,15 @@ export default {
   methods: {
     async createRelease() {
       this.createError = false;
+      const csrfToken = await getCsrf();
+      if (!csrfToken) {
+        return;
+      }
       const resp = await fetch('/api/v1/release', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          'X-CSRFToken': csrfToken,
         },
         body: JSON.stringify({
           release: {

--- a/rainfall-frontend/src/components/NewSite.vue
+++ b/rainfall-frontend/src/components/NewSite.vue
@@ -1,4 +1,6 @@
 <script lang="ts">
+import { getCsrf } from '../helpers/cookie';
+
 export default {
   data() {
     return {
@@ -9,10 +11,15 @@ export default {
   methods: {
     async createSite() {
       this.createError = false;
+      const csrfToken = await getCsrf();
+      if (!csrfToken) {
+        return;
+      }
       const resp = await fetch('/api/v1/site', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          'X-CSRFToken': csrfToken,
         },
         body: JSON.stringify({
           site: {

--- a/rainfall-frontend/src/components/NewSite.vue
+++ b/rainfall-frontend/src/components/NewSite.vue
@@ -11,15 +11,11 @@ export default {
   methods: {
     async createSite() {
       this.createError = false;
-      const csrfToken = await getCsrf();
-      if (!csrfToken) {
-        return;
-      }
       const resp = await fetch('/api/v1/site', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'X-CSRFToken': csrfToken,
+          'X-CSRFToken': await getCsrf(),
         },
         body: JSON.stringify({
           site: {

--- a/rainfall-frontend/src/components/PreviewSiteButton.vue
+++ b/rainfall-frontend/src/components/PreviewSiteButton.vue
@@ -22,13 +22,9 @@ export default {
       this.previewLoading = true;
       this.previewError = '';
 
-      const csrfToken = await getCsrf();
-      if (!csrfToken) {
-        return;
-      }
       const resp = await fetch(`/api/v1/preview/${this.siteId}`, {
         method: 'POST',
-        headers: { 'X-CSRFToken': csrfToken },
+        headers: { 'X-CSRFToken': await getCsrf() },
       });
 
       setTimeout(() => {

--- a/rainfall-frontend/src/components/PreviewSiteButton.vue
+++ b/rainfall-frontend/src/components/PreviewSiteButton.vue
@@ -1,4 +1,6 @@
 <script lang="ts">
+import { getCsrf } from '../helpers/cookie';
+
 export default {
   props: ['cardinality', 'siteId', 'readyForPreview'],
   data(): {
@@ -20,8 +22,13 @@ export default {
       this.previewLoading = true;
       this.previewError = '';
 
+      const csrfToken = await getCsrf();
+      if (!csrfToken) {
+        return;
+      }
       const resp = await fetch(`/api/v1/preview/${this.siteId}`, {
         method: 'POST',
+        headers: { 'X-CSRFToken': csrfToken },
       });
 
       setTimeout(() => {

--- a/rainfall-frontend/src/components/ReleasesList.vue
+++ b/rainfall-frontend/src/components/ReleasesList.vue
@@ -11,13 +11,9 @@ export default {
       this.$emit('song-uploaded');
     },
     async deleteFile(release: Release, id: string) {
-      const csrfToken = await getCsrf();
-      if (!csrfToken) {
-        return;
-      }
       const resp = await fetch(`/api/v1/file/${id}`, {
         method: 'DELETE',
-        headers: { 'X-CSRFToken': csrfToken },
+        headers: { 'X-CSRFToken': await getCsrf() },
       });
       if (!resp.ok) {
         if (resp.headers.get('Content-Type') == 'application/json') {

--- a/rainfall-frontend/src/components/ReleasesList.vue
+++ b/rainfall-frontend/src/components/ReleasesList.vue
@@ -1,6 +1,7 @@
 <script lang="ts">
 import SongUpload from './SongUpload.vue';
 import { type Release } from '../types/release';
+import { getCsrf } from '../helpers/cookie';
 
 export default {
   components: { SongUpload },
@@ -10,7 +11,14 @@ export default {
       this.$emit('song-uploaded');
     },
     async deleteFile(release: Release, id: string) {
-      const resp = await fetch(`/api/v1/file/${id}`, { method: 'DELETE' });
+      const csrfToken = await getCsrf();
+      if (!csrfToken) {
+        return;
+      }
+      const resp = await fetch(`/api/v1/file/${id}`, {
+        method: 'DELETE',
+        headers: { 'X-CSRFToken': csrfToken },
+      });
       if (!resp.ok) {
         if (resp.headers.get('Content-Type') == 'application/json') {
           const data = await resp.json();
@@ -61,7 +69,7 @@ export default {
           </button>
         </div>
         <div v-if="release.files.length == 0" class="text-right mt-4">
-          <span class="no-files-msg italic">No files uploaded yet</span>
+          <span class="no-files-msg italic">No files uploaded</span>
         </div>
         <hr class="my-4" />
         <div class="text-right">

--- a/rainfall-frontend/src/components/SongUpload.vue
+++ b/rainfall-frontend/src/components/SongUpload.vue
@@ -23,13 +23,9 @@ export default {
       }
       formData.append('release_id', this.releaseId);
 
-      const csrfToken = await getCsrf();
-      if (!csrfToken) {
-        return;
-      }
       const resp = await fetch('/api/v1/upload', {
         method: 'POST',
-        headers: { 'X-CSRFToken': csrfToken },
+        headers: { 'X-CSRFToken': await getCsrf() },
         body: formData,
       });
       if (resp.ok) {

--- a/rainfall-frontend/src/components/SongUpload.vue
+++ b/rainfall-frontend/src/components/SongUpload.vue
@@ -1,4 +1,6 @@
 <script lang="ts">
+import { getCsrf } from '../helpers/cookie';
+
 export default {
   props: ['releaseId'],
   data(): { files: FileList | null; fileError: string | null } {
@@ -20,9 +22,14 @@ export default {
         formData.append('song[]', song);
       }
       formData.append('release_id', this.releaseId);
+
+      const csrfToken = await getCsrf();
+      if (!csrfToken) {
+        return;
+      }
       const resp = await fetch('/api/v1/upload', {
         method: 'POST',
-        credentials: 'include',
+        headers: { 'X-CSRFToken': csrfToken },
         body: formData,
       });
       if (resp.ok) {

--- a/rainfall-frontend/src/helpers/cookie.ts
+++ b/rainfall-frontend/src/helpers/cookie.ts
@@ -1,0 +1,7 @@
+export async function getCsrf() {
+  await fetch('/api/v1/csrf');
+  return document.cookie
+    .split('; ')
+    .find((row) => row.startsWith('_csrf_token='))
+    ?.split('=')[1];
+}

--- a/rainfall-frontend/src/helpers/cookie.ts
+++ b/rainfall-frontend/src/helpers/cookie.ts
@@ -1,7 +1,9 @@
-export async function getCsrf() {
+export async function getCsrf(): Promise<string> {
   await fetch('/api/v1/csrf');
-  return document.cookie
-    .split('; ')
-    .find((row) => row.startsWith('_csrf_token='))
-    ?.split('=')[1];
+  return (
+    document.cookie
+      .split('; ')
+      .find((row) => row.startsWith('_csrf_token='))
+      ?.split('=')[1] || ''
+  );
 }

--- a/rainfall-frontend/src/stores/user.ts
+++ b/rainfall-frontend/src/stores/user.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia';
 import { type User } from '../types/user';
+import { getCsrf } from '../helpers/cookie';
 
 export const useUserStore = defineStore('user', {
   state(): { user: User | null; userPromise: Promise<User | null> | null } {
@@ -38,7 +39,14 @@ export const useUserStore = defineStore('user', {
       return this.userPromise;
     },
     async signOut() {
-      const resp = await fetch('/api/v1/logout');
+      const csrfToken = await getCsrf();
+      if (!csrfToken) {
+        return;
+      }
+      const resp = await fetch('/api/v1/logout', {
+        method: 'POST',
+        headers: { 'X-CSRFToken': csrfToken },
+      });
       if (resp.ok) {
         this.user = null;
       }

--- a/rainfall-frontend/src/stores/user.ts
+++ b/rainfall-frontend/src/stores/user.ts
@@ -39,13 +39,9 @@ export const useUserStore = defineStore('user', {
       return this.userPromise;
     },
     async signOut() {
-      const csrfToken = await getCsrf();
-      if (!csrfToken) {
-        return;
-      }
       const resp = await fetch('/api/v1/logout', {
         method: 'POST',
-        headers: { 'X-CSRFToken': csrfToken },
+        headers: { 'X-CSRFToken': await getCsrf() },
       });
       if (resp.ok) {
         this.user = null;

--- a/rainfall-frontend/src/views/WelcomeView.vue
+++ b/rainfall-frontend/src/views/WelcomeView.vue
@@ -25,13 +25,9 @@ export default {
   },
   methods: {
     async getStarted() {
-      const csrfToken = await getCsrf();
-      if (!csrfToken) {
-        return;
-      }
       const resp = await fetch('/api/v1/user/welcome', {
         method: 'POST',
-        headers: { 'X-CSRFToken': csrfToken },
+        headers: { 'X-CSRFToken': await getCsrf() },
       });
       if (resp.ok) {
         await this.userStore.loadUser(/* force */ true);

--- a/rainfall-frontend/src/views/WelcomeView.vue
+++ b/rainfall-frontend/src/views/WelcomeView.vue
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { mapStores } from 'pinia';
 import { useUserStore } from '../stores/user';
+import { getCsrf } from '../helpers/cookie';
 
 export default {
   data() {
@@ -24,7 +25,14 @@ export default {
   },
   methods: {
     async getStarted() {
-      const resp = await fetch('/api/v1/user/welcome', { method: 'POST' });
+      const csrfToken = await getCsrf();
+      if (!csrfToken) {
+        return;
+      }
+      const resp = await fetch('/api/v1/user/welcome', {
+        method: 'POST',
+        headers: { 'X-CSRFToken': csrfToken },
+      });
       if (resp.ok) {
         await this.userStore.loadUser(/* force */ true);
         this.$router.push('/sites');

--- a/rainfall/blueprint/user.py
+++ b/rainfall/blueprint/user.py
@@ -31,7 +31,7 @@ class UserBlueprintFactory:
                                 if field.name != 'sites')
       return flask.jsonify(user_without_sites)
 
-    @user.route('/logout')
+    @user.route('/logout', methods=['POST'])
     def logout():
       if 'user_id' in flask.session:
         del flask.session['user_id']

--- a/rainfall/blueprint/user.py
+++ b/rainfall/blueprint/user.py
@@ -12,58 +12,63 @@ from rainfall.decorators import with_current_site, with_current_user
 from rainfall.login import check_csrf, save_or_update_google_user
 from rainfall.models.user import User
 
-user = flask.Blueprint('user', __name__)
 
-GOOGLE_CLIENT_ID = os.environ['GOOGLE_CLIENT_ID']
-RAINFALL_FRONTEND_URL = os.environ['RAINFALL_FRONTEND_URL']
+class UserBlueprintFactory:
 
-log = logging.getLogger(__name__)
+  def __init__(self, csrf):
+    self.csrf = csrf
 
+  def get_blueprint(self):
+    user = flask.Blueprint('user', __name__)
 
-@user.route('/user')
-@with_current_user
-def get_user(user):
-  user_without_sites = dict((field.name, getattr(user, field.name))
-                            for field in fields(user)
-                            if field.name != 'sites')
-  return flask.jsonify(user_without_sites)
+    log = logging.getLogger(__name__)
 
+    @user.route('/user')
+    @with_current_user
+    def get_user(user):
+      user_without_sites = dict((field.name, getattr(user, field.name))
+                                for field in fields(user)
+                                if field.name != 'sites')
+      return flask.jsonify(user_without_sites)
 
-@user.route('/logout')
-def logout():
-  if 'user_id' in flask.session:
-    del flask.session['user_id']
-  return '', 204
+    @user.route('/logout')
+    def logout():
+      if 'user_id' in flask.session:
+        del flask.session['user_id']
+      return '', 204
 
+    @self.csrf.exempt
+    @user.route('/login', methods=['POST'])
+    def login():
+      resp = check_csrf()
+      if resp:
+        return resp
 
-@user.route('/login', methods=['POST'])
-def login():
-  resp = check_csrf()
-  if resp:
-    return resp
+      client_id = flask.current_app.config['GOOGLE_CLIENT_ID']
+      token = flask.request.form.get('credential')
+      try:
+        idinfo = id_token.verify_oauth2_token(token, goog_requests.Request(),
+                                              client_id)
+      except ValueError:
+        log.exception('Could not verify token, using: %s', client_id)
+        return flask.jsonify(status=400, error='Could not verify token'), 400
 
-  token = flask.request.form.get('credential')
-  try:
-    idinfo = id_token.verify_oauth2_token(token, goog_requests.Request(),
-                                          GOOGLE_CLIENT_ID)
-  except ValueError:
-    log.exception('Could not verify token, using: %s', GOOGLE_CLIENT_ID)
-    return flask.jsonify(status=400, error='Could not verify token'), 400
+      user_id = save_or_update_google_user(idinfo)
+      flask.session['user_id'] = user_id
+      user = db.session.get(User, user_id)
 
-  user_id = save_or_update_google_user(idinfo)
-  flask.session['user_id'] = user_id
-  user = db.session.get(User, user_id)
+      frontend_url = flask.current_app.config['RAINFALL_FRONTEND_URL']
+      if user.is_welcomed:
+        return flask.redirect(urljoin(frontend_url, '/sites'))
+      else:
+        return flask.redirect(urljoin(frontend_url, '/welcome'))
 
-  if user.is_welcomed:
-    return flask.redirect(urljoin(RAINFALL_FRONTEND_URL, '/sites'))
-  else:
-    return flask.redirect(urljoin(RAINFALL_FRONTEND_URL, '/welcome'))
+    @user.route('/user/welcome', methods=['POST'])
+    @with_current_user
+    def welcome(user):
+      user.is_welcomed = True
+      db.session.commit()
 
+      return '', 204
 
-@user.route('/user/welcome', methods=['POST'])
-@with_current_user
-def welcome(user):
-  user.is_welcomed = True
-  db.session.commit()
-
-  return '', 204
+    return user

--- a/rainfall/login.py
+++ b/rainfall/login.py
@@ -6,6 +6,8 @@ from rainfall.models.user import User
 
 
 def check_csrf():
+  # This is NOT the general CSRF protection provided by SeaSurf. This is a
+  # specific CSRF protection that Google login implements.
   csrf_token_cookie = flask.request.cookies.get('g_csrf_token')
   if not csrf_token_cookie:
     return flask.jsonify(status=400, error='No CSRF token in Cookie'), 400

--- a/rainfall/main.py
+++ b/rainfall/main.py
@@ -163,6 +163,11 @@ def create_app():
     return flask.send_from_directory(os.path.join('..', zip_path),
                                      'rainfall_site.zip')
 
+  @app.route('/api/v1/csrf')
+  def csrf():
+    # Empty route that simply sets the CSRF token.
+    return '', 204
+
   @app.route('/')
   @app.route('/<path:filename>')
   def index(filename=None):


### PR DESCRIPTION
The way this works:

1. All non-GET requests in the app are protected by flask-seasurf and require a CSRF token.
2. Frontend methods that call the API via POST first request `/api/v1/csrf` which sets the CSRF token in a cookie.
3. The frontend method contnues, extracting the token from the cookie and passing it in the `X-CSRFToken` header.
4. The seasurf middleware checks the token and allows or denies the request.

A request that fails via CSRF mismatch will be a 400 and the UI will display a "something went wrong" message, depending on the action being taken.