### PR TITLE
Ability to edit release names

### DIFF
--- a/rainfall-frontend/src/views/EditSiteView.vue
+++ b/rainfall-frontend/src/views/EditSiteView.vue
@@ -14,6 +14,7 @@ export default {
     site: null | Site;
     newSiteName: string;
     sitesError: string;
+    renameError: string;
     invalidateHandler: () => void;
     siteExists: boolean;
   } {
@@ -21,6 +22,7 @@ export default {
       site: null,
       newSiteName: '',
       sitesError: '',
+      renameError: '',
       invalidateHandler: () => {},
       siteExists: false,
     };
@@ -109,7 +111,9 @@ export default {
       if (!resp.ok) {
         if (resp.headers.get('Content-Type') == 'application/json') {
           const data = await resp.json();
-          this.sitesError = data.error;
+          this.renameError = data.error;
+        } else {
+          this.renameError = 'An unknown error occurred';
         }
         return;
       }
@@ -164,6 +168,9 @@ export default {
             Update name
           </button>
         </div>
+      </div>
+      <div v-if="renameError" class="text-right text-red-600 dark:text-red-400">
+        {{ renameError }}
       </div>
 
       <hr class="mt-12 md:hidden" />

--- a/rainfall/blueprint/upload.py
+++ b/rainfall/blueprint/upload.py
@@ -45,6 +45,7 @@ def write_files(release, claz, *files):
     # Write the file to the filesystem.
     cur_release_path = release_path(flask.current_app.config['DATA_DIR'],
                                     release)
+    os.makedirs(cur_release_path, exist_ok=True)
     song.save(os.path.join(cur_release_path, file.filename))
 
 

--- a/rainfall/blueprint/upload.py
+++ b/rainfall/blueprint/upload.py
@@ -42,11 +42,9 @@ def write_files(release, claz, *files):
     # Yield so that the calling function can properly save file to db.
     yield file
 
+    # Write the file to the filesystem.
     cur_release_path = release_path(flask.current_app.config['DATA_DIR'],
                                     release)
-    os.makedirs(cur_release_path, exist_ok=True)
-
-    # Write the file to the filesystem.
     song.save(os.path.join(cur_release_path, file.filename))
 
 

--- a/rainfall/site.py
+++ b/rainfall/site.py
@@ -132,3 +132,13 @@ def delete_file(clz, file_id, user):
   db.session.commit()
 
   return '', 204
+
+
+def rename_release_dir(data_dir_path, release, old_name):
+  os.rename(release_path(data_dir_path, release, override_name=old_name),
+            release_path(data_dir_path, release))
+
+
+def rename_site_dir(data_dir_path, site, old_name):
+  os.rename(site_path(data_dir_path, site, override_name=old_name),
+            site_path(data_dir_path, site))

--- a/rainfall/site.py
+++ b/rainfall/site.py
@@ -35,15 +35,27 @@ def cache_dir(preview_dir_path, site_id):
                       secure_filename(site.name), 'cache')
 
 
-def release_path(data_dir_path, release):
-  return os.path.join(data_dir_path, str(release.site.user.id),
-                      secure_filename(release.site.name),
-                      secure_filename(release.name))
+def site_path(data_dir_path, site, override_name=None):
+  name = override_name if override_name else site.name
+  return os.path.join(data_dir_path, str(site.user.id), secure_filename(name))
+
+
+def release_path(data_dir_path, release, override_name=None):
+  name = override_name if override_name else release.name
+  return os.path.join(site_path(data_dir_path, release.site),
+                      secure_filename(name))
 
 
 def site_exists(preview_dir_path, site_id):
   dir_ = build_dir(preview_dir_path, site_id)
   return os.path.exists(dir_) and len(os.listdir(dir_)) > 0
+
+
+def rename_site_dir(data_dir_path, site, old_name):
+  site = db.session.get(Site, UUID(site_id))
+
+  os.rename(site_path(data_dir_path, site, override_name=old_name),
+            site_path(data_dir_path, site))
 
 
 def generate_eno_files(data_dir_path, site_id):


### PR DESCRIPTION
This is similar to the work in #43, except for releases.

However there was a logic error, in that the site and release directories on disk, for Faircamp, were never renamed. So during preview, we looked for directories with the new name instead of the old one.

Now we rename the directories when the site/release is renamed. However we had to add logic to create those directories when the site/release is created. Previously, the full path to the release, including the site, was only created when a user uploaded a song.

Also better error handling for release/site renaming in the frontend.