### PR TITLE
Allow user to delete Sites

### DIFF
--- a/rainfall-frontend/cypress/e2e/edit_release.cy.ts
+++ b/rainfall-frontend/cypress/e2e/edit_release.cy.ts
@@ -183,23 +183,52 @@ describe('Edit Release test', () => {
         });
 
         it('displays a confirmation dialog', () => {
-          cy.get('#delete-modal').should('be.visible');
+          cy.get('.delete-modal').should('be.visible');
         });
 
         it('deletes the release', () => {
-          cy.get('#delete-modal').find('.confirm-delete').click();
+          cy.get('.delete-modal').find('.confirm-delete').click();
           cy.wait('@delete-release');
         });
 
         it('navigates to the site page of the release', () => {
-          cy.get('#delete-modal').find('.confirm-delete').click();
+          cy.get('.delete-modal').find('.confirm-delete').click();
           cy.wait('@delete-release');
           cy.url().should('eq', 'http://localhost:4173/site/065f4a1a-cd8a-7d4a-8000-b29784430f23');
         });
 
         it('closes the modal on cancel', () => {
-          cy.get('#delete-modal').find('.cancel-delete').click();
-          cy.get('#delete-modal').should('not.be.visible');
+          cy.get('.delete-modal').find('.cancel-delete').click();
+          cy.get('.delete-modal').should('not.be.visible');
+        });
+
+        it('closes the modal on close button click', () => {
+          cy.get('.delete-modal').find('.close-modal-button').click();
+          cy.get('.delete-modal').should('not.be.visible');
+        });
+
+        it('closes the modal on background click', () => {
+          cy.get('.delete-modal').click('topLeft');
+          cy.get('.delete-modal').should('not.be.visible');
+        });
+      });
+
+      describe('on delete error', () => {
+        beforeEach(() => {
+          cy.intercept('DELETE', 'api/v1/release/065f4a1a-f2e0-7d39-8000-0c3f69747e42', {
+            statusCode: 500,
+            body: {
+              status: 500,
+              error: 'Internal server error',
+            },
+          }).as('delete-release');
+          cy.get('#delete-release-button').click();
+          cy.get('.delete-modal').find('.confirm-delete').click();
+        });
+
+        it('displays an error message', () => {
+          cy.get('.delete-error-msg').should('be.visible');
+          cy.get('.delete-error-msg').should('contain', 'Internal server error');
         });
       });
     });

--- a/rainfall-frontend/cypress/e2e/edit_site.cy.ts
+++ b/rainfall-frontend/cypress/e2e/edit_site.cy.ts
@@ -328,30 +328,32 @@ describe('Edit Site test', () => {
           cy.get('.delete-modal').should('be.visible');
         });
 
+        // There are multiple modals on the page, one for each release and one for the site.
+        // We hardcode the index here to select the correct modal.
         it('deletes the release', () => {
-          cy.get('.delete-modal').first().find('.confirm-delete').click();
+          cy.get('.delete-modal').eq(1).find('.confirm-delete').click();
           cy.wait('@delete-release');
         });
 
         it('reloads the site with the release removed', () => {
-          cy.get('.delete-modal').first().find('.confirm-delete').click();
+          cy.get('.delete-modal').eq(1).find('.confirm-delete').click();
           cy.wait('@delete-release');
           cy.wait('@load-site');
         });
 
         it('closes the modal on cancel', () => {
-          cy.get('.delete-modal').first().find('.cancel-delete').click();
-          cy.get('.delete-modal').first().should('not.be.visible');
+          cy.get('.delete-modal').eq(1).find('.cancel-delete').click();
+          cy.get('.delete-modal').eq(1).should('not.be.visible');
         });
 
         it('closes the modal on close button click', () => {
-          cy.get('.delete-modal').first().find('.close-modal-button').click();
-          cy.get('.delete-modal').first().should('not.be.visible');
+          cy.get('.delete-modal').eq(1).find('.close-modal-button').click();
+          cy.get('.delete-modal').eq(1).should('not.be.visible');
         });
 
         it('closes the modal on background click', () => {
-          cy.get('.delete-modal').first().click('topLeft');
-          cy.get('.delete-modal').first().should('not.be.visible');
+          cy.get('#app').click('topLeft');
+          cy.get('.delete-modal').eq(1).should('not.be.visible');
         });
       });
     });

--- a/rainfall-frontend/cypress/e2e/edit_site.cy.ts
+++ b/rainfall-frontend/cypress/e2e/edit_site.cy.ts
@@ -37,6 +37,20 @@ describe('Edit Site test', () => {
       });
     });
 
+    // describe('deleting the site', () => {
+    //   beforeEach(() => {
+    //     cy.intercept('GET', 'api/v1/site/06547ed8-206f-7d3d-8000-20ab423e0bb9', {
+    //       fixture: 'site.json',
+    //     }).as('load-site');
+    //     cy.visit('/site/06547ed8-206f-7d3d-8000-20ab423e0bb9');
+    //     cy.wait('@load-site');
+    //   });
+
+    //   it('shows the delete button', () => {
+    //     cy.get('#delete-site-button').should('be.visible');
+    //   });
+    // });
+
     describe('when there is one release', () => {
       beforeEach(() => {
         let count = 0;
@@ -311,23 +325,33 @@ describe('Edit Site test', () => {
         });
 
         it('displays a confirmation dialog', () => {
-          cy.get('#delete-modal').should('be.visible');
+          cy.get('.delete-modal').should('be.visible');
         });
 
         it('deletes the release', () => {
-          cy.get('#delete-modal').find('.confirm-delete').click();
+          cy.get('.delete-modal').first().find('.confirm-delete').click();
           cy.wait('@delete-release');
         });
 
         it('reloads the site with the release removed', () => {
-          cy.get('#delete-modal').find('.confirm-delete').click();
+          cy.get('.delete-modal').first().find('.confirm-delete').click();
           cy.wait('@delete-release');
           cy.wait('@load-site');
         });
 
         it('closes the modal on cancel', () => {
-          cy.get('#delete-modal').find('.cancel-delete').click();
-          cy.get('#delete-modal').should('not.be.visible');
+          cy.get('.delete-modal').first().find('.cancel-delete').click();
+          cy.get('.delete-modal').first().should('not.be.visible');
+        });
+
+        it('closes the modal on close button click', () => {
+          cy.get('.delete-modal').first().find('.close-modal-button').click();
+          cy.get('.delete-modal').first().should('not.be.visible');
+        });
+
+        it('closes the modal on background click', () => {
+          cy.get('.delete-modal').first().click('topLeft');
+          cy.get('.delete-modal').first().should('not.be.visible');
         });
       });
     });

--- a/rainfall-frontend/cypress/e2e/sites.cy.ts
+++ b/rainfall-frontend/cypress/e2e/sites.cy.ts
@@ -74,5 +74,45 @@ describe('New Test', () => {
       cy.wait('@load-site');
       cy.url().should('eq', 'http://localhost:4173/site/06547ed8-206f-7d3d-8000-20ab423e0bb9');
     });
+
+    describe('when the delete button for a site is clicked', () => {
+      beforeEach(() => {
+        cy.intercept('GET', 'api/v1/site/list', { fixture: 'sites.json' }).as('load-sites');
+        cy.intercept('DELETE', 'api/v1/site/06547ed8-206f-7d3d-8000-20ab423e0bb9', {
+          statusCode: 204,
+        }).as('delete-site');
+        cy.get('.delete-site-overview-button').first().click();
+      });
+
+      it('shows the delete modal', () => {
+        cy.get('.delete-modal').should('be.visible');
+      });
+
+      it('deletes the site', () => {
+        cy.get('.delete-modal').first().find('.confirm-delete').click();
+        cy.wait('@delete-site');
+      });
+
+      it('reloads the sites with the site removed', () => {
+        cy.get('.delete-modal').first().find('.confirm-delete').click();
+        cy.wait('@delete-site');
+        cy.wait('@load-sites');
+      });
+
+      it('closes the modal on cancel', () => {
+        cy.get('.delete-modal').first().find('.cancel-delete').click();
+        cy.get('.delete-modal').first().should('not.be.visible');
+      });
+
+      it('closes the modal on close button click', () => {
+        cy.get('.delete-modal').first().find('.close-modal-button').click();
+        cy.get('.delete-modal').first().should('not.be.visible');
+      });
+
+      it('closes the modal on background click', () => {
+        cy.get('.delete-modal').first().click('topLeft');
+        cy.get('.delete-modal').first().should('not.be.visible');
+      });
+    });
   });
 });

--- a/rainfall-frontend/src/components/DeleteConfirmModal.vue
+++ b/rainfall-frontend/src/components/DeleteConfirmModal.vue
@@ -1,6 +1,15 @@
-<script>
+<script lang="ts">
 export default {
   props: ['displayMessage'],
+  methods: {
+    onConfirm() {
+      this.$emit('confirm-delete');
+      this.$emit('hide');
+    },
+    onCancel() {
+      this.$emit('hide');
+    },
+  },
 };
 </script>
 
@@ -13,9 +22,9 @@ export default {
     <div class="relative p-4 w-full max-w-md max-h-full">
       <div class="relative bg-white rounded-lg shadow dark:bg-gray-700">
         <button
+          @click="onCancel()"
           type="button"
           class="absolute top-3 end-2.5 text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm w-8 h-8 ms-auto inline-flex justify-center items-center dark:hover:bg-gray-600 dark:hover:text-white"
-          data-modal-hide="delete-modal"
         >
           <svg
             class="w-3 h-3"
@@ -54,15 +63,14 @@ export default {
             {{ displayMessage }}
           </h3>
           <button
-            @click="$emit('confirm-delete')"
-            data-modal-hide="delete-modal"
+            @click="onConfirm()"
             type="button"
             class="confirm-delete text-white bg-red-600 hover:bg-red-800 focus:ring-4 focus:outline-none focus:ring-red-300 dark:focus:ring-red-800 font-medium rounded-lg text-sm inline-flex items-center px-5 py-2.5 text-center"
           >
             Yes, delete
           </button>
           <button
-            data-modal-hide="delete-modal"
+            @click="onCancel()"
             type="button"
             class="cancel-delete py-2.5 px-5 ms-3 text-sm font-medium text-gray-900 focus:outline-none bg-white rounded-lg border border-gray-200 hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-4 focus:ring-gray-100 dark:focus:ring-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700"
           >

--- a/rainfall-frontend/src/components/DeleteConfirmModal.vue
+++ b/rainfall-frontend/src/components/DeleteConfirmModal.vue
@@ -28,9 +28,8 @@ export default {
 
 <template>
   <div
-    id="delete-modal"
     tabindex="-1"
-    class="hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full md:inset-0 h-[calc(100%-1rem)] max-h-full"
+    class="delete-modal hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full md:inset-0 h-[calc(100%-1rem)] max-h-full"
   >
     <div class="relative p-4 w-full max-w-md max-h-full">
       <div class="relative bg-white rounded-lg shadow dark:bg-gray-700">

--- a/rainfall-frontend/src/components/DeleteConfirmModal.vue
+++ b/rainfall-frontend/src/components/DeleteConfirmModal.vue
@@ -1,13 +1,26 @@
 <script lang="ts">
+import { Modal } from 'flowbite';
+
 export default {
   props: ['displayMessage'],
+  data(): { modal: Modal | null } {
+    return {
+      modal: null,
+    };
+  },
+  mounted() {
+    this.modal = new Modal(this.$el);
+  },
   methods: {
+    show() {
+      this.modal?.show();
+    },
     onConfirm() {
+      this.modal?.hide();
       this.$emit('confirm-delete');
-      this.$emit('hide');
     },
     onCancel() {
-      this.$emit('hide');
+      this.modal?.hide();
     },
   },
 };
@@ -24,7 +37,7 @@ export default {
         <button
           @click="onCancel()"
           type="button"
-          class="absolute top-3 end-2.5 text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm w-8 h-8 ms-auto inline-flex justify-center items-center dark:hover:bg-gray-600 dark:hover:text-white"
+          class="close-modal-button absolute top-3 end-2.5 text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm w-8 h-8 ms-auto inline-flex justify-center items-center dark:hover:bg-gray-600 dark:hover:text-white"
         >
           <svg
             class="w-3 h-3"

--- a/rainfall-frontend/src/components/DeleteConfirmModal.vue
+++ b/rainfall-frontend/src/components/DeleteConfirmModal.vue
@@ -1,3 +1,9 @@
+<script>
+export default {
+  props: ['displayMessage'],
+};
+</script>
+
 <template>
   <div
     id="delete-modal"
@@ -45,7 +51,7 @@
             />
           </svg>
           <h3 class="mb-5 text-lg font-normal text-gray-500 dark:text-gray-400">
-            Are you sure you want to delete this Release and all associated songs?
+            {{ displayMessage }}
           </h3>
           <button
             @click="$emit('confirm-delete')"

--- a/rainfall-frontend/src/components/NewSite.vue
+++ b/rainfall-frontend/src/components/NewSite.vue
@@ -51,9 +51,6 @@ export default {
           required
         />
       </div>
-      <p class="text-xs italic">
-        The title of your site is for your reference only and doesn't affect the output
-      </p>
       <button
         id="new-button"
         @click="createSite"

--- a/rainfall-frontend/src/components/Release.vue
+++ b/rainfall-frontend/src/components/Release.vue
@@ -238,15 +238,17 @@ export default defineComponent({
           </svg>
         </button>
       </div>
+      <div v-if="deleteSongError" class="delete-song-error-msg mt-2 text-red-600 dark:text-red-400">
+        <div>
+          {{ deleteSongError }}
+        </div>
+      </div>
       <div
-        v-if="deleteError || deleteSongError"
-        class="delete-error-msg mt-2 text-red-600 dark:text-red-400"
+        v-if="deleteError && !isEditing"
+        class="delete-error-msg-top mt-2 text-red-600 dark:text-red-400"
       >
         <div>
           {{ deleteError }}
-        </div>
-        <div>
-          {{ deleteSongError }}
         </div>
       </div>
       <div v-if="release.files.length == 0" class="text-right mt-4">
@@ -270,7 +272,7 @@ export default defineComponent({
       @confirm-delete="deleteRelease(release.id)"
       displayMessage="Are you sure you want to delete this Release and all associated songs?"
     ></DeleteConfirmModal>
-    <div class="md:max-w-screen-md pr-4">
+    <div v-if="isEditing" class="md:max-w-screen-md pr-4">
       <button
         @click="$refs.deleteModal?.show()"
         id="delete-release-button"

--- a/rainfall-frontend/src/components/Release.vue
+++ b/rainfall-frontend/src/components/Release.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, type PropType } from 'vue';
-import { initFlowbite } from 'flowbite';
+import { Modal } from 'flowbite';
 
 import ArtUpload from './ArtUpload.vue';
 import UploadButton from './UploadButton.vue';
@@ -14,7 +14,15 @@ export default defineComponent({
     isEditing: Boolean,
   },
   components: { ArtUpload, UploadButton, DeleteConfirmModal },
-  data() {
+  data(): {
+    newReleaseName: string;
+    currentDescription: string;
+    descriptionError: string | null;
+    renameError: string;
+    deleteError: string;
+    stashedDescription: string;
+    deleteModal: Modal | null;
+  } {
     return {
       newReleaseName: '',
       currentDescription: '',
@@ -22,6 +30,7 @@ export default defineComponent({
       renameError: '',
       deleteError: '',
       stashedDescription: '',
+      deleteModal: null,
     };
   },
   created() {
@@ -32,7 +41,8 @@ export default defineComponent({
     this.newReleaseName = this.release.name;
   },
   mounted() {
-    initFlowbite();
+    console.log(this.$refs.deleteModal.$el);
+    this.deleteModal = new Modal(this.$refs.deleteModal.$el);
   },
   methods: {
     onSongUploaded() {
@@ -177,12 +187,7 @@ export default defineComponent({
     <div v-if="!isEditing" class="p-2 bg-emerald-500 text-white">
       <div class="release-name text-xl">
         {{ release.name }}
-        <button
-          data-modal-target="delete-modal"
-          data-modal-toggle="delete-modal"
-          type="button"
-          class="delete-release-overview-button"
-        >
+        <button @click="deleteModal?.show()" type="button" class="delete-release-overview-button">
           <svg
             class="inline text-red-600 w-6 h-6 relative -top-0.5 ml-px"
             xmlns="http://www.w3.org/2000/svg"
@@ -252,7 +257,9 @@ export default defineComponent({
       </UploadButton>
     </div>
     <DeleteConfirmModal
+      ref="deleteModal"
       @confirm-delete="deleteRelease(release.id)"
+      @hide="deleteModal?.hide()"
       displayMessage="Are you sure you want to delete this Release and all associated songs?"
     ></DeleteConfirmModal>
   </div>

--- a/rainfall-frontend/src/components/Release.vue
+++ b/rainfall-frontend/src/components/Release.vue
@@ -4,16 +4,16 @@ import { initFlowbite } from 'flowbite';
 
 import ArtUpload from './ArtUpload.vue';
 import UploadButton from './UploadButton.vue';
-import DeleteReleaseModal from './DeleteReleaseModal.vue';
 import { type Release } from '../types/release';
 import { getCsrf } from '../helpers/cookie';
+import DeleteConfirmModal from './DeleteConfirmModal.vue';
 
 export default defineComponent({
   props: {
     release: { type: Object as PropType<Release | null>, required: true },
     isEditing: Boolean,
   },
-  components: { ArtUpload, UploadButton, DeleteReleaseModal },
+  components: { ArtUpload, UploadButton, DeleteConfirmModal },
   data() {
     return {
       newReleaseName: '',
@@ -251,7 +251,10 @@ export default defineComponent({
         Upload songs
       </UploadButton>
     </div>
-    <DeleteReleaseModal @confirm-delete="deleteRelease(release.id)"></DeleteReleaseModal>
+    <DeleteConfirmModal
+      @confirm-delete="deleteRelease(release.id)"
+      displayMessage="Are you sure you want to delete this Release and all associated songs?"
+    ></DeleteConfirmModal>
   </div>
 </template>
 

--- a/rainfall-frontend/src/components/Release.vue
+++ b/rainfall-frontend/src/components/Release.vue
@@ -1,6 +1,5 @@
 <script lang="ts">
 import { defineComponent, type PropType } from 'vue';
-import { Modal } from 'flowbite';
 
 import ArtUpload from './ArtUpload.vue';
 import UploadButton from './UploadButton.vue';
@@ -14,23 +13,15 @@ export default defineComponent({
     isEditing: Boolean,
   },
   components: { ArtUpload, UploadButton, DeleteConfirmModal },
-  data(): {
-    newReleaseName: string;
-    currentDescription: string;
-    descriptionError: string | null;
-    renameError: string;
-    deleteError: string;
-    stashedDescription: string;
-    deleteModal: Modal | null;
-  } {
+  data() {
     return {
       newReleaseName: '',
       currentDescription: '',
-      descriptionError: null,
+      descriptionError: '',
       renameError: '',
       deleteError: '',
+      deleteSongError: '',
       stashedDescription: '',
-      deleteModal: null,
     };
   },
   created() {
@@ -39,10 +30,6 @@ export default defineComponent({
     }
     this.currentDescription = this.release.description;
     this.newReleaseName = this.release.name;
-  },
-  mounted() {
-    console.log(this.$refs.deleteModal.$el);
-    this.deleteModal = new Modal(this.$refs.deleteModal.$el);
   },
   methods: {
     onSongUploaded() {
@@ -100,7 +87,9 @@ export default defineComponent({
       if (!resp.ok) {
         if (resp.headers.get('Content-Type') == 'application/json') {
           const data = await resp.json();
-          console.error(data.error);
+          this.deleteSongError = data.error;
+        } else {
+          this.deleteSongError = 'An unknown error occurred';
         }
         return;
       }
@@ -136,132 +125,166 @@ export default defineComponent({
 </script>
 
 <template>
-  <div v-if="release" class="release">
-    <div v-if="isEditing" class="max-w-screen-md md:flex md:justify-end my-2 md:mt-0">
-      <div class="flex flex-col md:flex-row w-full md:w-4/5 mb-2 justify-end items-center">
-        <input
-          id="site-name"
-          v-model="newReleaseName"
-          class="w-10/12 md:w-80 h-8 mt-2 md:mt-0 px-2 py-2 md:py-4 h-10 mr-0 md:mr-4 text-gray-600"
-        /><button
-          id="edit-name-button"
-          @click="updateName"
-          :disabled="!newReleaseName || newReleaseName === release.name"
-          class="cursor-pointer mt-4 md:mt-0 p-4 md:py-2 w-10/12 md:w-48 md:h-10 text-xl md:text-base disabled:cursor-auto bg-blue-600 text-gray-200 disabled:text-gray-600 disabled:text-white disabled:bg-blue-400 hover:bg-blue-800 disabled:hover:bg-blue-400 focus:ring-4 focus:outline-none focus:ring-blue-300 font-semibold text-gray-100 hover:text-white font-bold border border-blue-500 rounded hover:border-transparent disabled:hover:border-blue-500"
-        >
-          Update name
-        </button>
-      </div>
-    </div>
+  <div v-if="release">
     <div
-      v-if="renameError"
-      class="text-center md:text-right m-auto md:mr-0 w-80 md:w-auto text-red-600 dark:text-red-400 mb-4"
+      :class="isEditing ? 'md:max-w-screen-md mt-8 p-4 border border-emerald-500' : ''"
+      class="release"
     >
-      {{ renameError }}
-    </div>
+      <div v-if="isEditing" class="max-w-screen-md md:flex md:justify-end my-2 md:mt-0">
+        <div class="flex flex-col md:flex-row w-full md:w-4/5 mb-2 justify-end items-center">
+          <input
+            id="site-name"
+            v-model="newReleaseName"
+            class="w-10/12 md:w-80 h-8 mt-2 md:mt-0 px-2 py-2 md:py-4 h-10 mr-0 md:mr-4 text-gray-600"
+          /><button
+            id="edit-name-button"
+            @click="updateName"
+            :disabled="!newReleaseName || newReleaseName === release.name"
+            class="cursor-pointer mt-4 md:mt-0 p-4 md:py-2 w-10/12 md:w-48 md:h-10 text-xl md:text-base disabled:cursor-auto bg-blue-600 text-gray-200 disabled:text-gray-600 disabled:text-white disabled:bg-blue-400 hover:bg-blue-800 disabled:hover:bg-blue-400 focus:ring-4 focus:outline-none focus:ring-blue-300 font-semibold text-gray-100 hover:text-white font-bold border border-blue-500 rounded hover:border-transparent disabled:hover:border-blue-500"
+          >
+            Update name
+          </button>
+        </div>
+      </div>
+      <div
+        v-if="renameError"
+        class="text-center md:text-right m-auto md:mr-0 w-80 md:w-auto text-red-600 dark:text-red-400 mb-4"
+      >
+        {{ renameError }}
+      </div>
 
-    <div v-if="isEditing" class="flex flex-row flex-wrap justify-between">
-      <div class="art-upload-cont w-full md:w-[48%]">
-        <ArtUpload :releaseId="release.id"></ArtUpload>
+      <div v-if="isEditing" class="flex flex-row flex-wrap justify-between">
+        <div class="art-upload-cont w-full md:w-[48%]">
+          <ArtUpload :releaseId="release.id"></ArtUpload>
+        </div>
+        <div class="desc-edit-cont w-full md:w-[48%]">
+          <textarea
+            id="release-description"
+            v-model="release.description"
+            placeholder="Enter a description about your release"
+            class="w-full h-[24.75rem] text-black"
+          ></textarea>
+          <button
+            id="update-description-button"
+            :disabled="release.description === '' || release.description === currentDescription"
+            @click="updateDescription()"
+            class="block md:w-40 mx-auto md:ml-auto md:mr-0 cursor-pointer mt-4 w-10/12 p-4 md:py-2 text-xl md:text-base disabled:cursor-auto bg-blue-600 text-grey-200 disabled:bg-blue-400 disabled:text-white hover:bg-blue-800 disabled:hover:bg-blue-400 focus:ring-4 focus:outline-none focus:ring-blue-300 font-semibold text-gray-100 hover:text-white px-4 border border-blue-500 rounded hover:border-transparent disabled:hover:border-blue-500"
+          >
+            Update
+          </button>
+          <span v-if="descriptionError" class="text-red-600 dark:text-red-400">{{
+            descriptionError
+          }}</span>
+        </div>
       </div>
-      <div class="desc-edit-cont w-full md:w-[48%]">
-        <textarea
-          id="release-description"
-          v-model="release.description"
-          placeholder="Enter a description about your release"
-          class="w-full h-[24.75rem] text-black"
-        ></textarea>
-        <button
-          id="update-description-button"
-          :disabled="release.description === '' || release.description === currentDescription"
-          @click="updateDescription()"
-          class="block md:w-40 mx-auto md:ml-auto md:mr-0 cursor-pointer mt-4 w-10/12 p-4 md:py-2 text-xl md:text-base disabled:cursor-auto bg-blue-600 text-grey-200 disabled:bg-blue-400 disabled:text-white hover:bg-blue-800 disabled:hover:bg-blue-400 focus:ring-4 focus:outline-none focus:ring-blue-300 font-semibold text-gray-100 hover:text-white px-4 border border-blue-500 rounded hover:border-transparent disabled:hover:border-blue-500"
+      <div v-if="!isEditing" class="p-2 bg-emerald-500 text-white">
+        <div class="release-name text-xl">
+          {{ release.name }}
+          <button
+            @click="$refs.deleteModal?.show()"
+            type="button"
+            class="delete-release-overview-button"
+          >
+            <svg
+              class="inline text-red-600 w-6 h-6 relative -top-0.5 ml-px"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke-width="1.5"
+              stroke="currentColor"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="m9.75 9.75 4.5 4.5m0-4.5-4.5 4.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+              />
+            </svg>
+          </button>
+        </div>
+        <a
+          class="text-gray-800 hover:text-gray-500 hover:underline"
+          @click="editRelease(release.id)"
+          href="#"
+          >edit art/description</a
         >
-          Update
-        </button>
-        <span v-if="descriptionError" class="text-red-600 dark:text-red-400">{{
-          descriptionError
-        }}</span>
       </div>
-    </div>
-    <div v-if="!isEditing" class="p-2 bg-emerald-500 text-white">
-      <div class="release-name text-xl">
-        {{ release.name }}
-        <button @click="deleteModal?.show()" type="button" class="delete-release-overview-button">
+      <div v-else class="text-emerald-500 text-xl">
+        Songs
+        <hr class="h-px my-2 bg-emerald-500 border-0" />
+      </div>
+      <div
+        v-for="file of release.files"
+        class="file-name text-right my-3 flex items-center justify-end"
+      >
+        <div>{{ file.filename }}</div>
+        <button
+          @click="deleteFile(release, file.id)"
+          aria-label="delete file"
+          class="inline-block ml-2 text-red-500 relative top-0.5"
+        >
           <svg
-            class="inline text-red-600 w-6 h-6 relative -top-0.5 ml-px"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"
             stroke-width="1.5"
             stroke="currentColor"
+            class="w-6 h-6"
           >
             <path
               stroke-linecap="round"
               stroke-linejoin="round"
-              d="m9.75 9.75 4.5 4.5m0-4.5-4.5 4.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+              d="M9.75 9.75l4.5 4.5m0-4.5l-4.5 4.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
             />
           </svg>
         </button>
       </div>
-      <a
-        class="text-gray-800 hover:text-gray-500 hover:underline"
-        @click="editRelease(release.id)"
-        href="#"
-        >edit art/description</a
+      <div
+        v-if="deleteError || deleteSongError"
+        class="delete-error-msg mt-2 text-red-600 dark:text-red-400"
       >
-    </div>
-    <div v-else class="text-emerald-500 text-xl">
-      Songs
-      <hr class="h-px my-2 bg-emerald-500 border-0" />
-    </div>
-    <div
-      v-for="file of release.files"
-      class="file-name text-right my-3 flex items-center justify-end"
-    >
-      <div>{{ file.filename }}</div>
-      <button
-        @click="deleteFile(release, file.id)"
-        aria-label="delete file"
-        class="inline-block ml-2 text-red-500 relative top-0.5"
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke-width="1.5"
-          stroke="currentColor"
-          class="w-6 h-6"
+        <div>
+          {{ deleteError }}
+        </div>
+        <div>
+          {{ deleteSongError }}
+        </div>
+      </div>
+      <div v-if="release.files.length == 0" class="text-right mt-4">
+        <span class="no-files-msg italic">No files uploaded</span>
+      </div>
+      <hr v-if="!isEditing" class="my-4" />
+      <div class="text-right">
+        <UploadButton
+          :upload-url="`/api/v1/upload/release/${release.id}/song`"
+          param-name="song[]"
+          :accept-files="['.aiff', '.alac', '.aif', '.flac', '.mp3', '.ogg', '.opus', '.wav']"
+          @song-uploaded="onSongUploaded()"
+          class="md:ml-40"
         >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            d="M9.75 9.75l4.5 4.5m0-4.5l-4.5 4.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-          />
-        </svg>
-      </button>
-    </div>
-    <div v-if="release.files.length == 0" class="text-right mt-4">
-      <span class="no-files-msg italic">No files uploaded</span>
-    </div>
-    <hr v-if="!isEditing" class="my-4" />
-    <div class="text-right">
-      <UploadButton
-        :upload-url="`/api/v1/upload/release/${release.id}/song`"
-        param-name="song[]"
-        :accept-files="['.aiff', '.alac', '.aif', '.flac', '.mp3', '.ogg', '.opus', '.wav']"
-        @song-uploaded="onSongUploaded()"
-        class="md:ml-40"
-      >
-        Upload songs
-      </UploadButton>
+          Upload songs
+        </UploadButton>
+      </div>
     </div>
     <DeleteConfirmModal
       ref="deleteModal"
       @confirm-delete="deleteRelease(release.id)"
-      @hide="deleteModal?.hide()"
       displayMessage="Are you sure you want to delete this Release and all associated songs?"
     ></DeleteConfirmModal>
+    <div class="md:max-w-screen-md pr-4">
+      <button
+        @click="$refs.deleteModal?.show()"
+        id="delete-release-button"
+        class="block md:w-40 mx-auto md:ml-auto md:mr-0 cursor-pointer mt-4 w-10/12 p-4 md:py-2 text-xl md:text-base bg-red-500 text-grey-200 font-semibold rounded hover:text-white hover:bg-red-600"
+      >
+        Delete release
+      </button>
+      <div
+        v-if="deleteError"
+        class="delete-error-msg text-center md:text-right m-auto md:mr-0 w-80 md:w-auto text-red-600 dark:text-red-400 mb-4"
+      >
+        {{ deleteError }}
+      </div>
+    </div>
   </div>
 </template>
 

--- a/rainfall-frontend/src/components/SitesList.vue
+++ b/rainfall-frontend/src/components/SitesList.vue
@@ -1,6 +1,7 @@
 <script lang="ts">
-import { getCsrf } from '../helpers/cookie';
 import DeleteConfirmModal from './DeleteConfirmModal.vue';
+
+import { deleteSite as deleteSiteHelper } from '@/helpers/site';
 
 export default {
   components: { DeleteConfirmModal },
@@ -15,21 +16,9 @@ export default {
     editSite(id: string) {
       this.$router.push(`/site/${id}`);
     },
-    async deleteSite(id: string) {
-      const resp = await fetch(`/api/v1/site/${this.siteIdToDelete}`, {
-        method: 'DELETE',
-        headers: { 'X-CSRFToken': getCsrf() },
-      });
+    async deleteSite() {
+      this.deleteError = await deleteSiteHelper(this.siteIdToDelete);
       this.siteIdToDelete = null;
-      if (!resp.ok) {
-        if (resp.headers.get('Content-Type') == 'application/json') {
-          const data = await resp.json();
-          this.deleteError = data.error;
-        } else {
-          this.deleteError = 'An unknown error occurred';
-        }
-        return;
-      }
       this.$emit('site-deleted');
     },
   },

--- a/rainfall-frontend/src/helpers/site.ts
+++ b/rainfall-frontend/src/helpers/site.ts
@@ -1,0 +1,17 @@
+import { getCsrf } from './cookie';
+
+export async function deleteSite(id: string) {
+  const resp = await fetch(`/api/v1/site/${id}`, {
+    method: 'DELETE',
+    headers: { 'X-CSRFToken': getCsrf() },
+  });
+  if (!resp.ok) {
+    if (resp.headers.get('Content-Type') == 'application/json') {
+      const data = await resp.json();
+      return data.error;
+    } else {
+      return 'An unknown error occurred';
+    }
+    return '';
+  }
+}

--- a/rainfall-frontend/src/views/EditReleaseView.vue
+++ b/rainfall-frontend/src/views/EditReleaseView.vue
@@ -86,29 +86,11 @@ export default {
           Back to site
         </a>
       </div>
-      <div class="md:max-w-screen-md mt-8 p-4 border border-emerald-500">
-        <ReleaseComponent
-          :release="release"
-          @song-uploaded="loadRelease()"
-          :isEditing="true"
-        ></ReleaseComponent>
-      </div>
-      <div class="md:max-w-screen-md pr-4">
-        <button
-          id="delete-release-button"
-          class="block md:w-40 mx-auto md:ml-auto md:mr-0 cursor-pointer mt-4 w-10/12 p-4 md:py-2 text-xl md:text-base bg-red-500 text-grey-200 font-semibold rounded hover:text-white hover:bg-red-600"
-          data-modal-target="delete-modal"
-          data-modal-toggle="delete-modal"
-        >
-          Delete release
-        </button>
-        <div
-          v-if="deleteError"
-          class="text-center md:text-right m-auto md:mr-0 w-80 md:w-auto text-red-600 dark:text-red-400 mb-4"
-        >
-          {{ deleteError }}
-        </div>
-      </div>
+      <ReleaseComponent
+        :release="release"
+        @song-uploaded="loadRelease()"
+        :isEditing="true"
+      ></ReleaseComponent>
     </div>
   </div>
 </template>

--- a/rainfall-frontend/src/views/EditReleaseView.vue
+++ b/rainfall-frontend/src/views/EditReleaseView.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import ReleaseComponent from '@/components/Release.vue';
-import DeleteReleaseModal from '@/components/DeleteReleaseModal.vue';
+import DeleteReleaseModal from '@/components/DeleteConfirmModal.vue';
 
 import { mapStores } from 'pinia';
 import { useUserStore } from '../stores/user';

--- a/rainfall-frontend/src/views/EditSiteView.vue
+++ b/rainfall-frontend/src/views/EditSiteView.vue
@@ -5,11 +5,13 @@ import { type Site } from '../types/site';
 import AddReleaseButton from '../components/AddReleaseButton.vue';
 import DeployButton from '../components/DeployButton.vue';
 import PreviewSiteButton from '../components/PreviewSiteButton.vue';
+import DeleteConfirmModal from '../components/DeleteConfirmModal.vue';
 import Release from '../components/Release.vue';
 import { getCsrf } from '../helpers/cookie';
+import { deleteSite as deleteSiteHelper } from '@/helpers/site';
 
 export default {
-  components: { AddReleaseButton, DeployButton, PreviewSiteButton, Release },
+  components: { AddReleaseButton, DeployButton, PreviewSiteButton, Release, DeleteConfirmModal },
   data(): {
     site: null | Site;
     newSiteName: string;
@@ -17,6 +19,7 @@ export default {
     renameError: string;
     invalidateHandler: () => void;
     siteExists: boolean;
+    deleteError: string;
   } {
     return {
       site: null,
@@ -25,6 +28,7 @@ export default {
       renameError: '',
       invalidateHandler: () => {},
       siteExists: false,
+      deleteError: '',
     };
   },
   async created() {
@@ -88,6 +92,10 @@ export default {
         error = data.error;
       }
       this.sitesError = error;
+    },
+    async deleteSite(id: string) {
+      this.deleteError = await deleteSiteHelper(this.site.id);
+      this.$router.replace('/sites');
     },
     setInvalidateHandler(fn: () => void) {
       this.invalidateHandler = fn;
@@ -190,6 +198,21 @@ export default {
           @preview-requested="calculateSiteExists"
         />
         <DeployButton :site-id="site.id" :ready-for-deploy="readyForPreview && siteExists" />
+      </div>
+
+      <DeleteConfirmModal
+        ref="deleteModal"
+        @confirm-delete="deleteSite(site.id)"
+        displayMessage="Are you sure you want to delete this Site, all of its Releases, and all associated songs?"
+      ></DeleteConfirmModal>
+      <div class="flex flex-col md:flex-row mt-8 justify-right">
+        <button
+          @click="$refs.deleteModal?.show()"
+          id="delete-release-button"
+          class="block md:w-40 mx-auto md:ml-auto md:mr-0 cursor-pointer w-10/12 md:w-48 p-4 md:py-2 text-xl md:text-base bg-red-500 text-grey-200 font-semibold rounded hover:text-white hover:bg-red-600"
+        >
+          Delete Entire Site
+        </button>
       </div>
       <div
         v-if="site.releases.length > 0"

--- a/rainfall-frontend/src/views/SitesView.vue
+++ b/rainfall-frontend/src/views/SitesView.vue
@@ -1,11 +1,13 @@
 <script lang="ts">
 import { mapStores } from 'pinia';
-import { useUserStore } from '../stores/user';
-import NewSite from '../components/NewSite.vue';
-import SitesList from '../components/SitesList.vue';
+
+import { useUserStore } from '@/stores/user';
+import NewSite from '@/components/NewSite.vue';
+import SitesList from '@/components/SitesList.vue';
+import DeleteConfirmModal from '@/components/DeleteConfirmModal.vue';
 
 export default {
-  components: { NewSite, SitesList },
+  components: { NewSite, SitesList, DeleteConfirmModal },
   data() {
     return {
       sitesError: '',
@@ -66,7 +68,7 @@ export default {
         </p>
       </div>
       <NewSite @site-created="reloadSites()" class="mt-4" />
-      <SitesList :sites="sites" />
+      <SitesList :sites="sites" @site-deleted="reloadSites()" />
     </div>
   </div>
 </template>

--- a/rainfall-frontend/yarn.lock
+++ b/rainfall-frontend/yarn.lock
@@ -1061,9 +1061,9 @@ camelcase-css@^2.0.1:
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
 
 caniuse-lite@^1.0.30001538, caniuse-lite@^1.0.30001541:
-  version "1.0.30001669"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001669.tgz"
-  integrity sha512-DlWzFDJqstqtIVx1zeSpIMLjunf5SmwOw0N2Ck/QSQdS8PLS4+9HrLaYei4w8BIAL7IB/UEDu889d8vhCTPA0w==
+  version "1.0.30001677"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001677.tgz"
+  integrity sha512-fmfjsOlJUpMWu+mAAtZZZHz7UEwsUxIIvu1TJfO1HqFQvB/B+ii0xr9B5HpbZY/mC4XZ8SvjHJqtAY6pDPQEog==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
Contains a significant refactor of deleting Releases as well. The modal, which was already its own component, has been changed to internally implement a Flowbite Modal component. This proved more reliable then relying on data-* attributes and initializing Flowbite at "just the right time".

Comes with frontend and backend tests.

Also moved the "Delete entire Release" button from the `EditReleaseView` to the `Release` component itself. It only worked in it's previous location because the modal was on the page anyways from the `Release` component, and the data-* processing made it work.