### PR TITLE
Add CI check that frontend builds 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,3 +71,12 @@ jobs:
         with:
           name: screenshots
           path: rainfall-frontend/cypress/screenshots/*
+
+  build-check:
+    runs-on: ubuntu-latest
+    needs: [python-ci, frontend-ci]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Frontend builds successfully
+        run: cd rainfall-frontend && yarn run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,5 +78,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Javascript dependencies
+        run: cd rainfall-frontend && yarn install --frozen-lockfile
+        
       - name: Frontend builds successfully
-        run: cd rainfall-frontend && yarn run build
+        run: |
+          cd rainfall-frontend
+          yarn run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,13 +74,12 @@ jobs:
 
   build-check:
     runs-on: ubuntu-latest
-    needs: [python-ci, frontend-ci]
     steps:
       - uses: actions/checkout@v4
 
       - name: Install Javascript dependencies
         run: cd rainfall-frontend && yarn install --frozen-lockfile
-        
+
       - name: Frontend builds successfully
         run: |
           cd rainfall-frontend


### PR DESCRIPTION
Typescript checks are not run until the production build is produced. This means that, without this check, a PR could be merged that passes other tests but doesn't pass Typescript type safety.