### PR TITLE
Add celery config to adjust retry settings

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -23,7 +23,7 @@ services:
   redis:
     image: redis:latest
     ports:
-      - "6379:6379"
+      - "6355:6379"
 
 
   # Used for formatting the volume as ext4. Otherwise, some minio operations may fail.

--- a/rainfall/celeryconfig.py
+++ b/rainfall/celeryconfig.py
@@ -1,0 +1,10 @@
+import os
+
+broker_url = os.environ['REDIS_URL'],
+result_backend = os.environ['REDIS_URL']
+# Don't use a pool, connect every time. There seems to be an issue with
+# connections to Redis getting stale.
+broker_pool_limit = None
+# Retry forever if Redis is unreachable.
+broker_connection_max_retries = None
+broker_connection_retry_on_startup = True

--- a/rainfall/main.py
+++ b/rainfall/main.py
@@ -23,9 +23,8 @@ from rainfall.test_constants import TEST_FILE_PATH, TEST_MINIO_BUCKET
 log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG)
 
-task_app = Celery('tasks',
-                  broker_url=os.environ['REDIS_URL'],
-                  result_backend=os.environ['REDIS_URL'])
+task_app = Celery('tasks')
+task_app.config_from_object('rainfall.celeryconfig')
 
 
 @task_app.task


### PR DESCRIPTION
I've gotten multiple user reports now that previews have "hung" and not completed. This is definitely an issue with the Celery worker.

Looking in the worker logs, I see:

```
redis.exceptions.ConnectionError: Error while reading from fly-rainfall-redis.upstash.io:6379 : (104, 'Connection reset by peer')
```

It seems like it's losing the connection to the Upstash Redis. In this PR, I've attempted to stop using a worker pool (so connections don't get stale), use infinite retries, and retry on startup.

Hopefully this will fix the issue.